### PR TITLE
gpio-button-hotplug: fix conversion to devm_fwnode_gpiod_get()

### DIFF
--- a/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
+++ b/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
@@ -539,7 +539,7 @@ static int gpio_keys_button_probe(struct platform_device *pdev,
 				of_get_next_child(dev->of_node, prev);
 
 			bdata->gpiod = devm_fwnode_gpiod_get(dev,
-				of_fwnode_handle(child), "gpios", GPIOD_IN,
+				of_fwnode_handle(child), NULL, GPIOD_IN,
 				desc);
 
 			prev = child;


### PR DESCRIPTION
Conversion to devm_fwnode_gpiod_get() broke probing and returned -2 error code as devm_fwnode_gpiod_get() was failing to find the GPIO descriptor.

The issue is that "gpios" was used as the con_id, however this is not correct as the core will always look for the "gpios" or "gpio" suffix and thus it should not be passed as con_id, so simply pass NULL.
