### PR TITLE
generic: 6.6: fix uncompressed kallsyms

### DIFF
--- a/target/linux/generic/pending-6.6/203-kallsyms_uncompressed.patch
+++ b/target/linux/generic/pending-6.6/203-kallsyms_uncompressed.patch
@@ -65,17 +65,66 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static int absolute_percpu;
  static int base_relative;
  static int lto_clang;
-@@ -469,6 +470,9 @@ static void write_src(void)
+@@ -453,13 +454,15 @@ static void write_src(void)
+ 	}
+ 	printf("\n");
+ 
+-	/*
+-	 * Now that we wrote out the compressed symbol names, restore the
+-	 * original names, which are needed in some of the later steps.
+-	 */
+-	for (i = 0; i < table_cnt; i++) {
+-		expand_symbol(table[i]->sym, table[i]->len, buf);
+-		strcpy((char *)table[i]->sym, buf);
++	if (!uncompressed) {
++		/*
++		 * Now that we wrote out the compressed symbol names, restore the
++		 * original names, which are needed in some of the later steps.
++		 */
++		for (i = 0; i < table_cnt; i++) {
++			expand_symbol(table[i]->sym, table[i]->len, buf);
++			strcpy((char *)table[i]->sym, buf);
++		}
+ 	}
+ 
+ 	output_label("kallsyms_markers");
+@@ -469,20 +472,22 @@ static void write_src(void)
  
  	free(markers);
  
-+	if (uncompressed)
-+		return;
-+
- 	output_label("kallsyms_token_table");
- 	off = 0;
- 	for (i = 0; i < 256; i++) {
-@@ -582,6 +586,9 @@ static unsigned char *find_token(unsigne
+-	output_label("kallsyms_token_table");
+-	off = 0;
+-	for (i = 0; i < 256; i++) {
+-		best_idx[i] = off;
+-		expand_symbol(best_table[i], best_table_len[i], buf);
+-		printf("\t.asciz\t\"%s\"\n", buf);
+-		off += strlen(buf) + 1;
+-	}
+-	printf("\n");
++	if (!uncompressed) {
++		output_label("kallsyms_token_table");
++		off = 0;
++		for (i = 0; i < 256; i++) {
++			best_idx[i] = off;
++			expand_symbol(best_table[i], best_table_len[i], buf);
++			printf("\t.asciz\t\"%s\"\n", buf);
++			off += strlen(buf) + 1;
++		}
++		printf("\n");
+ 
+-	output_label("kallsyms_token_index");
+-	for (i = 0; i < 256; i++)
+-		printf("\t.short\t%d\n", best_idx[i]);
+-	printf("\n");
++		output_label("kallsyms_token_index");
++		for (i = 0; i < 256; i++)
++			printf("\t.short\t%d\n", best_idx[i]);
++		printf("\n");
++	}
+ 
+ 	if (!base_relative)
+ 		output_label("kallsyms_addresses");
+@@ -582,6 +587,9 @@ static unsigned char *find_token(unsigne
  {
  	int i;
  
@@ -85,7 +134,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	for (i = 0; i < len - 1; i++) {
  		if (str[i] == token[0] && str[i+1] == token[1])
  			return &str[i];
-@@ -654,6 +661,9 @@ static void optimize_result(void)
+@@ -654,6 +662,9 @@ static void optimize_result(void)
  {
  	int i, best;
  
@@ -95,7 +144,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	/* using the '\0' symbol last allows compress_symbols to use standard
  	 * fast string functions */
  	for (i = 255; i >= 0; i--) {
-@@ -815,6 +825,7 @@ int main(int argc, char **argv)
+@@ -815,6 +826,7 @@ int main(int argc, char **argv)
  			{"absolute-percpu", no_argument, &absolute_percpu, 1},
  			{"base-relative",   no_argument, &base_relative,   1},
  			{"lto-clang",       no_argument, &lto_clang,       1},


### PR DESCRIPTION
Currently, the existing uncompressed kallsym support is causing qualcommax boards to hang on boot, and only after earlycon and verbose BUG() prints are enabled the trace is visible:
```
[    0.000000] ------------[ cut here ]------------
[    0.000000] kernel BUG at kernel/kallsyms.c:340!
[    0.000000] Internal error: Oops - BUG: 00000000f2000800 [#1] SMP
```

Felix has fixed up the uncompressed kallsyms support so modify the current patch with the fix.
All credits for the code go to Felix.
