### PR TITLE
Fixes for Linux 6.6 round 2

### DIFF
--- a/package/kernel/linux/modules/input.mk
+++ b/package/kernel/linux/modules/input.mk
@@ -11,7 +11,7 @@ define KernelPackage/hid
   SUBMENU:=$(INPUT_MODULES_MENU)
   TITLE:=HID Devices
   DEPENDS:=+kmod-input-core +kmod-input-evdev
-  KCONFIG:=CONFIG_HID CONFIG_HIDRAW=y CONFIG_HID_BATTERY_STRENGTH=y
+  KCONFIG:=CONFIG_HID CONFIG_HID_SUPPORT=y CONFIG_HIDRAW=y CONFIG_HID_BATTERY_STRENGTH=y
   FILES:=$(LINUX_DIR)/drivers/hid/hid.ko
   AUTOLOAD:=$(call AutoLoad,61,hid)
 endef

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -378,7 +378,7 @@ $(eval $(call KernelPackage,phy-smsc))
 define KernelPackage/phy-airoha-en8811h
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Airoha EN8811H 2.5G Ethernet PHY
-  DEPENDS:=+airoha-en8811h-firmware +kmod-libphy @LINUX_6_1
+  DEPENDS:=+airoha-en8811h-firmware +kmod-libphy @!LINUX_5_15
   KCONFIG:=CONFIG_AIR_EN8811H_PHY
   FILES:= \
    $(LINUX_DIR)/drivers/net/phy/air_en8811h.ko

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1573,7 +1573,7 @@ $(eval $(call KernelPackage,pcs-xpcs))
 define KernelPackage/stmmac-core
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Synopsis Ethernet Controller core (NXP,STMMicro,others)
-  DEPENDS:=@TARGET_x86_64||TARGET_armsr_armv8 +kmod-pcs-xpcs +kmod-ptp
+  DEPENDS:=@TARGET_x86_64||TARGET_armsr_armv8 +kmod-pcs-xpcs +LINUX_6_6:kmod-of-mdio +kmod-ptp
   KCONFIG:=CONFIG_STMMAC_ETH \
     CONFIG_STMMAC_SELFTESTS=n \
     CONFIG_STMMAC_PLATFORM \

--- a/package/utils/fitblk/Makefile
+++ b/package/utils/fitblk/Makefile
@@ -16,7 +16,7 @@ define Package/fitblk
   SECTION:=base
   CATEGORY:=Base system
   TITLE:=fitblk firmware release tool
-  DEPENDS:=@LINUX_6_1
+  DEPENDS:=@!LINUX_5_15
 endef
 
 define Package/fitblk/description

--- a/target/linux/generic/pending-6.6/450-11-block-implement-NVMEM-provider.patch
+++ b/target/linux/generic/pending-6.6/450-11-block-implement-NVMEM-provider.patch
@@ -97,7 +97,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	if (!bnv->bdev->bd_disk->fops->open)
 +		return -EIO;
 +
-+	ret = bnv->bdev->bd_disk->fops->open(bnv->bdev, FMODE_READ);
++	ret = bnv->bdev->bd_disk->fops->open(bnv->bdev->bd_disk, BLK_OPEN_READ);
 +	if (ret)
 +		return ret;
 +
@@ -119,12 +119,12 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	}
 +
 +err_release_bdev:
-+	bnv->bdev->bd_disk->fops->release(bnv->bdev->bd_disk, FMODE_READ);
++	bnv->bdev->bd_disk->fops->release(bnv->bdev->bd_disk);
 +
 +	return ret;
 +}
 +
-+static int blk_nvmem_register(struct device *dev, struct class_interface *iface)
++static int blk_nvmem_register(struct device *dev)
 +{
 +	struct device_node *np = dev_of_node(dev);
 +	struct block_device *bdev = dev_to_bdev(dev);
@@ -192,7 +192,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	return 0;
 +}
 +
-+static void blk_nvmem_unregister(struct device *dev, struct class_interface *iface)
++static void blk_nvmem_unregister(struct device *dev)
 +{
 +	struct block_device *bdev = dev_to_bdev(dev);
 +	struct blk_nvmem *bnv_c, *bnv = NULL;

--- a/target/linux/generic/pending-6.6/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.6/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
@@ -1,4 +1,4 @@
-From 0de82310d2b32e78ff79d42c08b1122a6ede3778 Mon Sep 17 00:00:00 2001
+From e52faf1564a8bcaf866f9a6c7bf0e8a8748afb15 Mon Sep 17 00:00:00 2001
 From: Daniel Golle <daniel@makrotopia.org>
 Date: Sun, 30 Apr 2023 00:15:41 +0100
 Subject: [PATCH] net: phy: realtek: detect early version of RTL8221B
@@ -10,11 +10,22 @@ Implement custom identify function using the PKGID instead of iterating
 over the implemented MMDs.
 
 Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ drivers/net/phy/realtek.c | 50 ++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 49 insertions(+), 1 deletion(-)
 
 --- a/drivers/net/phy/realtek.c
 +++ b/drivers/net/phy/realtek.c
-@@ -780,6 +780,38 @@ static int rtl8226_match_phy_device(stru
- 	       rtlgen_supports_2_5gbps(phydev);
+@@ -81,6 +81,7 @@
+ 
+ #define RTL_GENERIC_PHYID			0x001cc800
+ #define RTL_8211FVD_PHYID			0x001cc878
++#define RTL_8221B_VB_CG				0x001cc849
+ 
+ MODULE_DESCRIPTION("Realtek PHY driver");
+ MODULE_AUTHOR("Johnson Leung");
+@@ -799,6 +800,54 @@ static int rtl822x_probe(struct phy_devi
+ 	return 0;
  }
  
 +static int rtl8221b_vb_cg_match_phy_device(struct phy_device *phydev)
@@ -22,7 +33,15 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	int val;
 +	u32 id;
 +
-+	if (phydev->drv->read_mmd) {
++	if (phydev->is_c45) {
++		if (phydev->c45_ids.device_ids[1])
++			return phydev->c45_ids.device_ids[1] == RTL_8221B_VB_CG;
++	} else {
++		if (phydev->phy_id)
++			return phydev->phy_id == RTL_8221B_VB_CG;
++	}
++
++	if (phydev->mdio.bus->read_c45) {
 +		val = phy_read_mmd(phydev, MDIO_MMD_PMAPMD, MDIO_PKGID1);
 +		if (val < 0)
 +			return 0;
@@ -46,13 +65,21 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +		id |= val;
 +	}
 +
-+	return (id == 0x001cc849);
++	if (id != RTL_8221B_VB_CG)
++		return 0;
++
++	if (phydev->is_c45)
++		phydev->c45_ids.device_ids[1] = id;
++	else
++		phydev->phy_id = id;
++
++	return 1;
 +}
 +
- static int rtl822x_probe(struct phy_device *phydev)
+ static int rtlgen_resume(struct phy_device *phydev)
  {
- 	struct device *dev = &phydev->mdio.dev;
-@@ -1132,7 +1164,7 @@ static struct phy_driver realtek_drvs[]
+ 	int ret = genphy_resume(phydev);
+@@ -1132,7 +1181,7 @@ static struct phy_driver realtek_drvs[]
  		.write_page     = rtl821x_write_page,
  		.soft_reset     = genphy_soft_reset,
  	}, {

--- a/target/linux/generic/pending-6.6/741-net-phy-realtek-support-interrupt-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.6/741-net-phy-realtek-support-interrupt-of-RTL8221B.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/phy/realtek.c
 +++ b/drivers/net/phy/realtek.c
-@@ -1007,6 +1007,51 @@ static int rtl8221b_config_init(struct p
+@@ -1024,6 +1024,51 @@ static int rtl8221b_config_init(struct p
  	return 0;
  }
  
@@ -52,7 +52,7 @@
  static struct phy_driver realtek_drvs[] = {
  	{
  		PHY_ID_MATCH_EXACT(0x00008201),
-@@ -1169,6 +1214,8 @@ static struct phy_driver realtek_drvs[]
+@@ -1186,6 +1231,8 @@ static struct phy_driver realtek_drvs[]
  		.get_features   = rtl822x_get_features,
  		.config_init    = rtl8221b_config_init,
  		.config_aneg    = rtl822x_config_aneg,


### PR DESCRIPTION
Another bunch of generic fixes for Linux 6.6 support in preparation of adding support for Linux 6.6 to the mediatek target.