### PR TITLE
kernel: crypto: crypto-rng: select SHA3 for kernel 6.6

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -872,7 +872,7 @@ $(eval $(call KernelPackage,crypto-rmd160))
 
 define KernelPackage/crypto-rng
   TITLE:=CryptoAPI random number generation
-  DEPENDS:=+kmod-crypto-hash +kmod-crypto-hmac +kmod-crypto-sha512
+  DEPENDS:=+kmod-crypto-hash +kmod-crypto-hmac +kmod-crypto-sha512 +LINUX_6_6:kmod-crypto-sha3
   KCONFIG:= \
 	CONFIG_CRYPTO_DRBG \
 	CONFIG_CRYPTO_DRBG_HMAC=y \


### PR DESCRIPTION
jitterentropy_rng requires SHA3 support for kernel 6.6, so lets make sure its selected as a dependency.

Please make sure to rebase on top of OpenWrt main as I pushed the required sha3 kmod there.
